### PR TITLE
Add: Comprehensive Playwright E2E tests for existing functionality

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [
     ["list"], // Simple list reporter for console output
+    ["html", { open: "never" }], // HTML report for CI artifacts
   ],
   use: {
     baseURL: process.env.TEST_BASE_URL || "http://localhost:5173",

--- a/client/tests/error-handling.spec.ts
+++ b/client/tests/error-handling.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Error Handling", () => {
+  test("displays error for non-existent room", async ({ page }) => {
+    await page.goto("/room/non-existent-room-code");
+
+    // Should show error message
+    await expect(page.locator("text=Error loading room")).toBeVisible();
+  });
+
+  test("displays loading state while fetching room", async ({ page }) => {
+    // Navigate to a room page
+    await page.goto("/room/some-room-code");
+
+    // Either we see loading state or error (depending on timing)
+    await expect(
+      page.locator("text=Loading room data...").or(page.locator("text=Error"))
+    ).toBeVisible();
+  });
+});
+
+test.describe("Room Join Validation", () => {
+  test("join button is disabled without nickname", async ({ page }) => {
+    // First create a room to get a valid room code
+    await page.goto("/new");
+    await page.fill("#nickname", "Creator");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    // Get the room URL
+    const roomUrl = page.url();
+
+    // Open a new context (different user)
+    const newContext = await page.context().browser()!.newContext();
+    const newPage = await newContext.newPage();
+
+    await newPage.goto(roomUrl);
+
+    // The join button should be disabled when nickname is empty
+    const joinButton = newPage.locator('button:has-text("Join Room")');
+    await expect(joinButton).toBeDisabled();
+
+    await newContext.close();
+  });
+
+  test("join button is enabled when nickname is entered", async ({ page }) => {
+    // First create a room
+    await page.goto("/new");
+    await page.fill("#nickname", "Creator");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    const roomUrl = page.url();
+
+    // Open a new context (different user)
+    const newContext = await page.context().browser()!.newContext();
+    const newPage = await newContext.newPage();
+
+    await newPage.goto(roomUrl);
+
+    // Fill in nickname
+    await newPage.fill("#join-nickname", "NewUser");
+
+    // The join button should now be enabled
+    const joinButton = newPage.locator('button:has-text("Join Room")');
+    await expect(joinButton).toBeEnabled();
+
+    await newContext.close();
+  });
+});

--- a/client/tests/example.spec.ts
+++ b/client/tests/example.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('/');
-  
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Pomowave/);
-});

--- a/client/tests/home.spec.ts
+++ b/client/tests/home.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home Page", () => {
+  test("has correct title", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Pomowave/);
+  });
+
+  test("displays main heading and description", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("h1")).toHaveText("Pomowave");
+    await expect(
+      page.locator("p:has-text('Create a new room')")
+    ).toBeVisible();
+  });
+
+  test("has Create Room button", async ({ page }) => {
+    await page.goto("/");
+    const createRoomButton = page.locator(".create-room-btn");
+    await expect(createRoomButton).toBeVisible();
+    await expect(createRoomButton).toHaveText("Create Room");
+  });
+
+  test("Create Room button navigates to /new", async ({ page }) => {
+    await page.goto("/");
+    await page.click(".create-room-btn");
+    await expect(page).toHaveURL("/new");
+  });
+});

--- a/client/tests/room-creation.spec.ts
+++ b/client/tests/room-creation.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Room Creation", () => {
+  test("displays new room form", async ({ page }) => {
+    await page.goto("/new");
+    await expect(page.locator("h1")).toHaveText("Create a New Room");
+    await expect(page.locator('label[for="nickname"]')).toBeVisible();
+    await expect(page.locator("#nickname")).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toHaveText(
+      "Create Room"
+    );
+  });
+
+  test("submit button is disabled when nickname is empty", async ({ page }) => {
+    await page.goto("/new");
+    const submitButton = page.locator('button[type="submit"]');
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test("submit button is enabled when nickname is entered", async ({
+    page,
+  }) => {
+    await page.goto("/new");
+    await page.fill("#nickname", "TestUser");
+    const submitButton = page.locator('button[type="submit"]');
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test("creates room and redirects to room page", async ({ page }) => {
+    await page.goto("/new");
+    await page.fill("#nickname", "TestHost");
+    await page.click('button[type="submit"]');
+
+    // Wait for navigation to room page
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    // Verify we're on the room page
+    const roomCode = page.url().split("/").pop();
+    await expect(page.locator("h1")).toContainText(`Room: ${roomCode}`);
+  });
+
+  test("room creator is marked as host", async ({ page }) => {
+    await page.goto("/new");
+    await page.fill("#nickname", "HostUser");
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    // Verify the user appears in the list as host
+    await expect(
+      page.locator('.users-list li:has-text("HostUser")')
+    ).toBeVisible();
+    await expect(
+      page.locator('.users-list li:has-text("(Host)")')
+    ).toBeVisible();
+  });
+
+  test("room creator does not see join form", async ({ page }) => {
+    await page.goto("/new");
+    await page.fill("#nickname", "Creator");
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    // The join form should not be visible for the room creator
+    await expect(
+      page.locator('button:has-text("Join Room")')
+    ).not.toBeVisible();
+    await expect(
+      page.locator("h2:has-text('Welcome to the room!')")
+    ).toBeVisible();
+  });
+
+  test("share link button is visible in room", async ({ page }) => {
+    await page.goto("/new");
+    await page.fill("#nickname", "Sharer");
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/\/room\/[\w-]+/);
+
+    await expect(page.locator('button:has-text("Share Link")')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Add E2E tests covering the main application features:
- Home page tests (title, heading, Create Room navigation)
- Room creation tests (form validation, redirect, host status, share link)
- Error handling tests (invalid rooms, join form validation)
- Updated Playwright config with HTML reporter for CI artifacts

https://claude.ai/code/session_01LGYW6Zx3b5cC5KZon4C4G9