### PR TITLE
Add 60-second window for joining waves

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -58,3 +58,18 @@ export const startTimer = async (roomCode: string, userId: string, durationMinut
   }
   return response.json();
 };
+
+// API function to join an active wave
+export const joinWave = async (roomCode: string, userId: string) => {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomCode}/wave/join`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ userId }),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error: ${response.status}`);
+  }
+  return response.json();
+};

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -16,8 +16,9 @@ export type PomoSession = {
   id: string;
   startedAt: number; // Unix timestamp (ms)
   startedBy: string; // User ID
-  participants: string[]; // User IDs who were in the room
+  participants: string[]; // User IDs who joined the wave
   durationMinutes: number;
+  joinDeadline: number; // Unix timestamp (ms) - deadline for joining the wave (60s after start)
 };
 
 export type Room = {


### PR DESCRIPTION
When someone starts a wave, other users in the room now have 60 seconds to click "Join Wave" to participate. If they don't join within the deadline, they appear on the beach like late joiners.

Changes:
- Add joinDeadline field to PomoSession type
- Only wave starter is auto-added as participant
- Add POST /api/rooms/:roomId/wave/join endpoint
- Add joinWave API function in client
- Show "Join Wave" button with countdown in WaveScene

https://claude.ai/code/session_01MkdrWSgQf271urCE6sowKt