### PR TITLE
Display timer countdown in browser tab title

### DIFF
--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -95,6 +95,26 @@ function Room() {
     }
   }, [timeRemaining]);
 
+  // Sync timer status to browser tab title
+  useEffect(() => {
+    const formatTime = (ms: number) => {
+      const totalSeconds = Math.floor(ms / 1000);
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    };
+
+    if (timeRemaining !== null && timeRemaining > 0) {
+      document.title = `${formatTime(timeRemaining)} - Pomowave`;
+    } else {
+      document.title = 'Pomowave';
+    }
+
+    return () => {
+      document.title = 'Pomowave';
+    };
+  }, [timeRemaining]);
+
   // Update join deadline remaining time
   useEffect(() => {
     const sessions = roomData?.room?.sessions || [];


### PR DESCRIPTION
## Summary
Added a feature to sync the Pomowave timer countdown to the browser tab title, allowing users to see the remaining time at a glance without switching to the application window.

## Changes
- Added a new `useEffect` hook that updates `document.title` with the formatted countdown timer
- Implemented `formatTime` utility function to convert milliseconds to MM:SS format
- Timer displays in tab title when active (e.g., "05:30 - Pomowave")
- Falls back to "Pomowave" when timer is inactive or completed
- Cleanup function resets title on component unmount

## Implementation Details
- The effect depends on `timeRemaining` to reactively update as the timer counts down
- Time formatting uses zero-padded minutes and seconds for consistent display
- Null checks ensure the feature only activates when a timer is actually running

https://claude.ai/code/session_01SkK75FpouWvhgaTXx9223K