### PR TITLE
Add keyboard shortcuts and hotkeys modal to Room page

### DIFF
--- a/client/src/components/HotkeysModal.tsx
+++ b/client/src/components/HotkeysModal.tsx
@@ -1,0 +1,108 @@
+type HotkeysModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const styles = {
+  overlay: {
+    position: 'fixed' as const,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  modal: {
+    background: 'white',
+    borderRadius: '16px',
+    padding: '24px',
+    maxWidth: '320px',
+    width: '90%',
+    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px',
+  },
+  title: {
+    fontSize: '1.125rem',
+    fontWeight: 600,
+    color: '#1e293b',
+    margin: 0,
+  },
+  closeButton: {
+    background: 'transparent',
+    border: 'none',
+    fontSize: '1.5rem',
+    cursor: 'pointer',
+    color: '#64748b',
+    padding: '4px',
+    lineHeight: 1,
+  },
+  hotkey: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 0',
+    borderBottom: '1px solid #e2e8f0',
+  },
+  hotkeyLast: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 0',
+  },
+  action: {
+    fontSize: '0.875rem',
+    color: '#334155',
+  },
+  key: {
+    background: '#f1f5f9',
+    border: '1px solid #e2e8f0',
+    borderRadius: '6px',
+    padding: '4px 12px',
+    fontSize: '0.75rem',
+    fontFamily: 'monospace',
+    color: '#475569',
+    fontWeight: 500,
+  },
+};
+
+function HotkeysModal({ isOpen, onClose }: HotkeysModalProps) {
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div style={styles.overlay} onClick={handleOverlayClick}>
+      <div style={styles.modal}>
+        <div style={styles.header}>
+          <h2 style={styles.title}>Keyboard Shortcuts</h2>
+          <button style={styles.closeButton} onClick={onClose}>
+            &times;
+          </button>
+        </div>
+        <div style={styles.hotkey}>
+          <span style={styles.action}>Start pomo / Join wave</span>
+          <span style={styles.key}>Space</span>
+        </div>
+        <div style={styles.hotkeyLast}>
+          <span style={styles.action}>Close modal</span>
+          <span style={styles.key}>Esc</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HotkeysModal;


### PR DESCRIPTION
## Summary
This PR adds keyboard shortcut support and a hotkeys modal to the Room page, improving user experience by allowing quick actions via keyboard.

## Key Changes
- **New HotkeysModal component**: A styled modal that displays available keyboard shortcuts (Space to start/join, Esc to close modal)
- **Keyboard event handling**: Added `handleKeyDown` callback to Room component that:
  - Listens for Space key to start a new pomodoro or join an active wave
  - Listens for Escape key to close the hotkeys modal
  - Ignores keyboard input when user is typing in input/textarea fields
- **UI updates**: 
  - Added "Hotkeys" button in the header next to "Share Link" button
  - Button opens the hotkeys modal when clicked
  - Modal can be closed by clicking the X button, pressing Escape, or clicking the overlay

## Implementation Details
- Keyboard event listener is registered/unregistered via useEffect to prevent memory leaks
- Modal uses inline styles for styling consistency with existing components
- Overlay click detection ensures modal only closes when clicking outside the modal content
- Keyboard shortcuts respect user state (only allows actions if user has joined the room)
- Prevents default Space key behavior to avoid page scrolling

https://claude.ai/code/session_01GTGLG3PDkUqsi6teT9Lusc