### PR TITLE
Add notifications when other users start a wave session

### DIFF
--- a/client/src/services/notifications.ts
+++ b/client/src/services/notifications.ts
@@ -187,6 +187,22 @@ export function showStartNotification(): void {
 }
 
 /**
+ * Show a browser notification when someone else starts a wave
+ */
+export function showWaveStartedNotification(starterName: string): void {
+  if (!('Notification' in window) || Notification.permission !== 'granted') {
+    return;
+  }
+
+  new Notification(`${starterName} started a wave! 🌊`, {
+    body: 'Join now to ride together!',
+    icon: '🏄',
+    tag: 'wave-started',
+    requireInteraction: false,
+  });
+}
+
+/**
  * Show a browser notification for timer completion
  */
 export function showCompleteNotification(): void {
@@ -217,4 +233,12 @@ export async function notifyTimerStart(): Promise<void> {
 export function notifyTimerComplete(): void {
   playCompleteSound();
   showCompleteNotification();
+}
+
+/**
+ * Notify user that someone else started a wave (sound + browser notification)
+ */
+export function notifyWaveStarted(starterName: string): void {
+  playStartSound();
+  showWaveStartedNotification(starterName);
 }


### PR DESCRIPTION
## Summary
This PR adds browser notifications and audio alerts when another user starts a wave session in the room, keeping all participants informed of activity in real-time.

## Key Changes
- **New notification function**: Added `notifyWaveStarted()` and `showWaveStartedNotification()` to the notifications service that displays a browser notification with the starter's name and plays an audio cue
- **Wave detection logic**: Implemented a new `useEffect` hook in the Room component that detects when a new wave session is created by comparing the current session ID with the previous one
- **Smart notification filtering**: The notification only triggers when:
  - The user has joined the room
  - A new session has been created (different ID from the previous session)
  - The session was started by someone other than the current user
  - The component has completed its initial load (prevents spurious notifications on mount)
- **Session tracking**: Added `prevSessionIdRef` to track the previous session ID, using `undefined` to distinguish between "not initialized" and "no active session" states

## Implementation Details
- The wave detection uses the room's sessions array and compares the latest session ID with the previously stored value
- User information is looked up from the room's users list to display the starter's nickname in the notification
- The notification includes a wave emoji (🌊) and encourages users to join with the message "Join now to ride together!"
- Uses the existing `playStartSound()` function to provide audio feedback consistent with other notifications

https://claude.ai/code/session_01Vhq4EZFbX4y7AinhFJ4WwM