### PR TITLE
Add room validation and display room details on home page

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -73,3 +73,24 @@ export const joinWave = async (roomCode: string, userId: string) => {
   }
   return response.json();
 };
+
+// Type for room details returned by validation
+export type RoomDetails = {
+  users: { nickname: string; emoji: string }[];
+  wavesCompleted: number;
+} | null;
+
+// API function to validate multiple rooms and get their details
+export const validateRooms = async (roomIds: string[]): Promise<{ roomDetails: Record<string, RoomDetails> }> => {
+  const response = await fetch(`${API_BASE_URL}/rooms/validate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ roomIds }),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error: ${response.status}`);
+  }
+  return response.json();
+};


### PR DESCRIPTION
## Summary
This PR adds the ability to validate rooms and display rich room information (active users and waves completed) on the home page. It also implements automatic pruning of non-existent rooms from localStorage.

## Key Changes

- **New API endpoint** (`POST /api/rooms/validate`): Validates multiple rooms in a single request and returns room details including active users and waves completed
- **New API client function** (`validateRooms`): Client-side wrapper for the room validation endpoint with TypeScript types
- **Enhanced home page**: 
  - Displays user emojis and wave count for each room
  - Shows loading state while validating rooms
  - Automatically removes rooms from localStorage if they no longer exist on the server
  - Gracefully falls back to showing stored rooms if validation fails
- **Improved UX**: Room cards now show up to 5 user emojis with a "+N" indicator for additional users, plus the number of completed waves

## Implementation Details

- Room validation happens on component mount via `useEffect`
- Non-existent rooms (where server returns `null`) are pruned from localStorage to keep the list clean
- The validation includes error handling with console logging and fallback behavior
- New styles added for room details display with proper spacing and typography
- Loading state prevents UI flashing while rooms are being validated

https://claude.ai/code/session_01RZUuZRHke3f3QLqDUtK99B