### PR TITLE
Add work declaration feature to pomodoro sessions

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -45,13 +45,13 @@ export const joinRoom = async (roomCode: string, nickname: string) => {
 };
 
 // API function to start a timer in a room
-export const startTimer = async (roomCode: string, userId: string, durationMinutes: number = 25) => {
+export const startTimer = async (roomCode: string, userId: string, durationMinutes: number = 25, workDeclaration?: string) => {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomCode}/timer`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ userId, durationMinutes }),
+    body: JSON.stringify({ userId, durationMinutes, workDeclaration: workDeclaration || undefined }),
   });
   if (!response.ok) {
     throw new Error(`HTTP error: ${response.status}`);
@@ -60,13 +60,13 @@ export const startTimer = async (roomCode: string, userId: string, durationMinut
 };
 
 // API function to join an active wave
-export const joinWave = async (roomCode: string, userId: string) => {
+export const joinWave = async (roomCode: string, userId: string, workDeclaration?: string) => {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomCode}/wave/join`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ userId }),
+    body: JSON.stringify({ userId, workDeclaration: workDeclaration || undefined }),
   });
   if (!response.ok) {
     throw new Error(`HTTP error: ${response.status}`);

--- a/client/src/components/BeachScene.tsx
+++ b/client/src/components/BeachScene.tsx
@@ -12,6 +12,8 @@ type BeachSceneProps = {
   onStartTimer: () => void;
   isStarting: boolean;
   timerComplete?: boolean;
+  workDeclaration: string;
+  onWorkDeclarationChange: (value: string) => void;
 };
 
 const styles = {
@@ -103,9 +105,27 @@ const styles = {
     height: '20px',
     background: 'linear-gradient(180deg, rgba(59, 130, 246, 0.3) 0%, transparent 100%)',
   },
+  workInput: {
+    padding: '10px 14px',
+    borderRadius: '10px',
+    border: '2px solid rgba(255,255,255,0.5)',
+    background: 'rgba(255,255,255,0.7)',
+    fontSize: '0.875rem',
+    outline: 'none',
+    textAlign: 'center' as const,
+    width: '100%',
+    maxWidth: '280px',
+    color: '#1e3a5f',
+    boxSizing: 'border-box' as const,
+  },
+  workInputContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    paddingBottom: '8px',
+  },
 };
 
-function BeachScene({ users, onStartTimer, isStarting, timerComplete }: BeachSceneProps) {
+function BeachScene({ users, onStartTimer, isStarting, timerComplete, workDeclaration, onWorkDeclarationChange }: BeachSceneProps) {
   return (
     <div style={styles.container}>
       <div style={styles.sun}>☀️</div>
@@ -122,6 +142,17 @@ function BeachScene({ users, onStartTimer, isStarting, timerComplete }: BeachSce
             <div style={styles.towel}></div>
           </div>
         ))}
+      </div>
+
+      <div style={styles.workInputContainer}>
+        <input
+          type="text"
+          placeholder="What are you working on? (optional)"
+          value={workDeclaration}
+          onChange={(e) => onWorkDeclarationChange(e.target.value)}
+          style={styles.workInput}
+          maxLength={100}
+        />
       </div>
 
       <div style={styles.buttonContainer}>

--- a/client/src/components/CelebrationScene.tsx
+++ b/client/src/components/CelebrationScene.tsx
@@ -25,6 +25,7 @@ type CelebrationSceneProps = {
   floatingEmojis: FloatingEmoji[];
   isParticipant: boolean;
   onDismiss: () => void;
+  workDeclarations?: Record<string, string>;
 };
 
 const REACTION_EMOJIS = ['🎉', '🔥', '💪', '🌊', '🏄', '⭐'];
@@ -143,6 +144,16 @@ const styles = {
     fontSize: '1rem',
     zIndex: 1,
   },
+  workLabel: {
+    fontSize: '0.625rem',
+    color: 'rgba(255,255,255,0.8)',
+    marginTop: '2px',
+    maxWidth: '80px',
+    textAlign: 'center' as const,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
 };
 
 function CelebrationScene({
@@ -155,6 +166,7 @@ function CelebrationScene({
   floatingEmojis,
   isParticipant,
   onDismiss,
+  workDeclarations = {},
 }: CelebrationSceneProps) {
   const [progress, setProgress] = useState(0);
 
@@ -217,6 +229,11 @@ function CelebrationScene({
               <Avatar nickname={user.nickname} emoji={user.emoji} />
             </div>
             <div style={styles.surfboard}></div>
+            {workDeclarations[user.id] && (
+              <div style={styles.workLabel} title={workDeclarations[user.id]}>
+                {workDeclarations[user.id]}
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/client/src/components/SessionHistory.tsx
+++ b/client/src/components/SessionHistory.tsx
@@ -11,11 +11,13 @@ type PomoSession = {
   startedBy: string;
   participants: string[];
   durationMinutes: number;
+  workDeclarations?: Record<string, string>;
 };
 
 type SessionHistoryProps = {
   sessions: PomoSession[];
   users: User[];
+  showWorkDeclarations?: boolean;
 };
 
 const styles = {
@@ -92,9 +94,15 @@ const styles = {
     fontSize: '0.875rem',
     color: '#0ea5e9',
   },
+  workText: {
+    fontSize: '0.625rem',
+    color: '#64748b',
+    marginLeft: '2px',
+    fontStyle: 'italic' as const,
+  },
 };
 
-function SessionHistory({ sessions, users }: SessionHistoryProps) {
+function SessionHistory({ sessions, users, showWorkDeclarations }: SessionHistoryProps) {
   const getUserById = (id: string) => users.find(u => u.id === id);
 
   const formatSessionTime = (timestamp: number) => {
@@ -139,6 +147,7 @@ function SessionHistory({ sessions, users }: SessionHistoryProps) {
                   {session.participants.map((participantId) => {
                     const user = getUserById(participantId);
                     const isStarter = participantId === session.startedBy;
+                    const work = showWorkDeclarations && session.workDeclarations?.[participantId];
                     return (
                       <div key={participantId} style={styles.participant}>
                         <span style={styles.participantEmoji}>
@@ -146,6 +155,7 @@ function SessionHistory({ sessions, users }: SessionHistoryProps) {
                         </span>
                         <span>{user?.nickname || 'Unknown'}</span>
                         {isStarter && <span style={styles.starterBadge}>⭐</span>}
+                        {work && <span style={styles.workText}>- {work}</span>}
                       </div>
                     );
                   })}

--- a/client/src/components/WaveScene.tsx
+++ b/client/src/components/WaveScene.tsx
@@ -17,6 +17,9 @@ type WaveSceneProps = {
   joinDeadlineRemaining: number | null;
   onJoinWave: () => void;
   isJoiningWave: boolean;
+  workDeclarations: Record<string, string>;
+  workDeclaration: string;
+  onWorkDeclarationChange: (value: string) => void;
 };
 
 const styles = {
@@ -165,6 +168,30 @@ const styles = {
     color: 'rgba(255,255,255,0.8)',
     marginTop: '6px',
   },
+  workLabel: {
+    fontSize: '0.625rem',
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: '2px',
+    maxWidth: '80px',
+    textAlign: 'center' as const,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  workInput: {
+    padding: '8px 12px',
+    borderRadius: '8px',
+    border: '2px solid rgba(255,255,255,0.4)',
+    background: 'rgba(255,255,255,0.15)',
+    fontSize: '0.8rem',
+    outline: 'none',
+    textAlign: 'center' as const,
+    width: '100%',
+    maxWidth: '240px',
+    color: 'white',
+    boxSizing: 'border-box' as const,
+    marginBottom: '8px',
+  },
 };
 
 function WaveScene({
@@ -176,7 +203,10 @@ function WaveScene({
   canJoinWave,
   joinDeadlineRemaining,
   onJoinWave,
-  isJoiningWave
+  isJoiningWave,
+  workDeclarations,
+  workDeclaration,
+  onWorkDeclarationChange,
 }: WaveSceneProps) {
   const formatTime = (ms: number) => {
     const totalSeconds = Math.floor(ms / 1000);
@@ -224,6 +254,11 @@ function WaveScene({
                 <Avatar nickname={user.nickname} emoji={user.emoji} />
               </div>
               <div style={styles.surfboard}></div>
+              {workDeclarations[user.id] && (
+                <div style={styles.workLabel} title={workDeclarations[user.id]}>
+                  {workDeclarations[user.id]}
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -235,6 +270,14 @@ function WaveScene({
           <div style={styles.joinWaveLabel}>
             <Avatar nickname={currentUserCanJoin.nickname} emoji={currentUserCanJoin.emoji} size="small" />
           </div>
+          <input
+            type="text"
+            placeholder="Working on... (optional)"
+            value={workDeclaration}
+            onChange={(e) => onWorkDeclarationChange(e.target.value)}
+            style={styles.workInput}
+            maxLength={100}
+          />
           <button
             style={{
               ...styles.joinWaveButton,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -19,6 +19,7 @@ export type PomoSession = {
   participants: string[]; // User IDs who joined the wave
   durationMinutes: number;
   joinDeadline: number; // Unix timestamp (ms) - deadline for joining the wave (60s after start)
+  workDeclarations?: Record<string, string>; // userId -> what they're working on (optional)
 };
 
 export type Room = {


### PR DESCRIPTION
## Summary
This PR adds the ability for users to declare what they're working on during pomodoro sessions. Users can optionally specify their work task when starting a timer or joining an active wave, and this information is displayed during the session and in the session history.

## Key Changes

- **API Updates**: Extended `startTimer` and `joinWave` endpoints to accept optional `workDeclaration` parameter
- **Client Components**: 
  - Added work declaration input fields to `BeachScene` (when starting a timer) and `WaveScene` (when joining a wave)
  - Display work declarations in `CelebrationScene` and `WaveScene` under user avatars
  - Show work declarations in `SessionHistory` with optional toggle
- **State Management**: Added `workDeclaration` state in `Room.tsx` and `celebrationWorkDeclarations` to track declarations across sessions
- **Server**: 
  - Store work declarations in `PomoSession` as a `Record<string, string>` mapping user IDs to their work tasks
  - Persist work declarations when users start timers or join waves
  - Emit work declaration data in WebSocket events

## Implementation Details

- Work declarations are optional and trimmed of whitespace before storage
- Input fields have a 100-character limit
- Work declarations are displayed with ellipsis overflow handling in celebration and wave scenes
- Session history can optionally display work declarations via `showWorkDeclarations` prop
- Work declarations are preserved throughout the session lifecycle and displayed in the celebration scene

https://claude.ai/code/session_019B9ZuAnRyXJxK9PtkzW4Sc