### PR TITLE
Add support for late joins to waves after deadline

### DIFF
--- a/client/src/components/CelebrationScene.tsx
+++ b/client/src/components/CelebrationScene.tsx
@@ -18,6 +18,7 @@ export type FloatingEmoji = {
 type CelebrationSceneProps = {
   users: User[];
   participantIds: string[];
+  partialParticipantIds: string[];
   durationMinutes: number;
   onStartTimer: () => void;
   isStarting: boolean;
@@ -154,11 +155,26 @@ const styles = {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap' as const,
   },
+  paddleboard: {
+    width: '30px',
+    height: '6px',
+    background: 'linear-gradient(90deg, #94a3b8 0%, #64748b 100%)',
+    borderRadius: '6px',
+    marginTop: '2px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+  },
+  partialBadge: {
+    fontSize: '0.5rem',
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: '1px',
+    fontStyle: 'italic' as const,
+  },
 };
 
 function CelebrationScene({
   users,
   participantIds,
+  partialParticipantIds,
   durationMinutes,
   onStartTimer,
   isStarting,
@@ -171,6 +187,8 @@ function CelebrationScene({
   const [progress, setProgress] = useState(0);
 
   const participants = users.filter(u => participantIds.includes(u.id));
+  const partialParticipants = users.filter(u => partialParticipantIds.includes(u.id));
+  const totalSurfers = participants.length + partialParticipants.length;
 
   // Auto-dismiss progress timer
   useEffect(() => {
@@ -212,7 +230,7 @@ function CelebrationScene({
 
       <div style={styles.title}>Wave Caught! 🏄</div>
       <div style={styles.stats}>
-        {durationMinutes} min &middot; {participants.length} surfer{participants.length !== 1 ? 's' : ''}
+        {durationMinutes} min &middot; {totalSurfers} surfer{totalSurfers !== 1 ? 's' : ''}
       </div>
 
       {/* Participant lineup */}
@@ -229,6 +247,27 @@ function CelebrationScene({
               <Avatar nickname={user.nickname} emoji={user.emoji} />
             </div>
             <div style={styles.surfboard}></div>
+            {workDeclarations[user.id] && (
+              <div style={styles.workLabel} title={workDeclarations[user.id]}>
+                {workDeclarations[user.id]}
+              </div>
+            )}
+          </div>
+        ))}
+        {partialParticipants.map((user, index) => (
+          <div
+            key={user.id}
+            style={{
+              ...styles.surferWrapper,
+              animationDelay: `${(participants.length + index) * 0.1}s`,
+              opacity: 0.85,
+            }}
+          >
+            <div style={styles.avatarOnBoard}>
+              <Avatar nickname={user.nickname} emoji={user.emoji} />
+            </div>
+            <div style={styles.paddleboard}></div>
+            <div style={styles.partialBadge}>joined late</div>
             {workDeclarations[user.id] && (
               <div style={styles.workLabel} title={workDeclarations[user.id]}>
                 {workDeclarations[user.id]}

--- a/client/src/components/SessionHistory.tsx
+++ b/client/src/components/SessionHistory.tsx
@@ -10,6 +10,7 @@ type PomoSession = {
   startedAt: number;
   startedBy: string;
   participants: string[];
+  partialParticipants?: string[];
   durationMinutes: number;
   workDeclarations?: Record<string, string>;
 };
@@ -18,6 +19,7 @@ type SessionHistoryProps = {
   sessions: PomoSession[];
   users: User[];
   showWorkDeclarations?: boolean;
+  showPartialJoins?: boolean;
 };
 
 const styles = {
@@ -100,9 +102,14 @@ const styles = {
     marginLeft: '2px',
     fontStyle: 'italic' as const,
   },
+  partialBadge: {
+    fontSize: '0.625rem',
+    color: '#d97706',
+    marginLeft: '2px',
+  },
 };
 
-function SessionHistory({ sessions, users, showWorkDeclarations }: SessionHistoryProps) {
+function SessionHistory({ sessions, users, showWorkDeclarations, showPartialJoins }: SessionHistoryProps) {
   const getUserById = (id: string) => users.find(u => u.id === id);
 
   const formatSessionTime = (timestamp: number) => {
@@ -155,6 +162,20 @@ function SessionHistory({ sessions, users, showWorkDeclarations }: SessionHistor
                         </span>
                         <span>{user?.nickname || 'Unknown'}</span>
                         {isStarter && <span style={styles.starterBadge}>⭐</span>}
+                        {work && <span style={styles.workText}>- {work}</span>}
+                      </div>
+                    );
+                  })}
+                  {showPartialJoins && session.partialParticipants?.map((participantId) => {
+                    const user = getUserById(participantId);
+                    const work = showWorkDeclarations && session.workDeclarations?.[participantId];
+                    return (
+                      <div key={participantId} style={{ ...styles.participant, opacity: 0.8 }}>
+                        <span style={styles.participantEmoji}>
+                          {user?.emoji || '🐚'}
+                        </span>
+                        <span>{user?.nickname || 'Unknown'}</span>
+                        <span style={styles.partialBadge}>late</span>
                         {work && <span style={styles.workText}>- {work}</span>}
                       </div>
                     );

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -29,6 +29,7 @@ interface UserJoinedWaveEvent {
   userId: string;
   nickname: string;
   emoji: string;
+  partial?: boolean;
 }
 
 export interface WaveReactionEvent {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -16,7 +16,8 @@ export type PomoSession = {
   id: string;
   startedAt: number; // Unix timestamp (ms)
   startedBy: string; // User ID
-  participants: string[]; // User IDs who joined the wave
+  participants: string[]; // User IDs who joined the wave during the join window
+  partialParticipants?: string[]; // User IDs who joined after the join deadline (in-progress join)
   durationMinutes: number;
   joinDeadline: number; // Unix timestamp (ms) - deadline for joining the wave (60s after start)
   workDeclarations?: Record<string, string>; // userId -> what they're working on (optional)


### PR DESCRIPTION
## Summary
This PR adds support for users to join waves after the join deadline has passed, marking them as "partial" participants. These late joiners are visually distinguished from full participants and tracked separately throughout the application.

## Key Changes

- **Partial Participant Tracking**: Added `partialParticipants` field to `PomoSession` to track users who join after the deadline, separate from full participants
- **Late Join UI**: Created a new "Join Late" section in WaveScene that appears when the deadline has passed, with distinct styling (amber/orange gradient) and a "joined late" badge
- **Visual Distinction**: Partial participants are displayed with reduced opacity (0.85) and a "joined late" badge in both WaveScene and CelebrationScene
- **Updated Join Logic**: Modified the join wave endpoint to determine if a join is partial (after deadline) and add users to the appropriate list
- **Celebration Updates**: Updated CelebrationScene to display partial participants and include them in the surfer count
- **Session History**: Enhanced SessionHistory to show partial joins with a "late" badge when `showPartialJoins` prop is enabled
- **Type Updates**: Updated `PomoSession` type definition to include optional `partialParticipants` field and added `partial` flag to `UserJoinedWaveEvent`

## Implementation Details

- Partial participants are visually indicated with a paddleboard element and "joined late" italic text below their avatar
- The join late button uses a white background with amber text to distinguish it from the standard join button
- Users cannot join if they're already a full or partial participant
- Work declarations are supported for both full and partial participants
- The `wouldBePartialJoin` flag is computed based on whether the join deadline has passed, allowing the UI to show the appropriate join section

https://claude.ai/code/session_019FJ7BqMY8xXL2kmh7TerYw